### PR TITLE
Add support to vertical align quiverkeys

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -211,6 +211,9 @@ Keyword arguments:
     A dictionary with keyword arguments accepted by the
     :class:`~matplotlib.font_manager.FontProperties` initializer:
     *family*, *style*, *variant*, *size*, *weight*
+  
+  *vswap*:
+    Swap the horizontal key to a vertical key
 
 Any additional keyword arguments are used to override vector
 properties taken from *Q*.
@@ -240,6 +243,8 @@ class QuiverKey(martist.Artist):
         self.color = kw.pop('color', None)
         self.label = label
         self._labelsep_inches = kw.pop('labelsep', 0.1)
+        self._vswap = kw.pop('vswap',False)
+        vswap = {True: 'vertical', False: 0}
         self.labelsep = (self._labelsep_inches * Q.ax.figure.dpi)
 
         # try to prevent closure over the real self
@@ -267,6 +272,7 @@ class QuiverKey(martist.Artist):
                         text=label,  # bbox=boxprops,
                         horizontalalignment=self.halign[self.labelpos],
                         verticalalignment=self.valign[self.labelpos],
+                        rotation=vswap[self._vswap],
                         fontproperties=font_manager.FontProperties(**_fp))
 
         if self.labelcolor is not None:
@@ -295,8 +301,12 @@ class QuiverKey(martist.Artist):
             # Hack: save and restore the Umask
             _mask = self.Q.Umask
             self.Q.Umask = ma.nomask
-            self.verts = self.Q._make_verts(np.array([self.U]),
-                                            np.zeros((1,)))
+            if self._vswap:
+                self.verts = self.Q._make_verts(np.zeros((1,)),
+                                                array([self.U]))
+            else:
+                self.verts = self.Q._make_verts(np.array([self.U]),
+                                                np.zeros((1,)))
             self.Q.Umask = _mask
             self.Q.pivot = _pivot
             kw = self.Q.polykw


### PR DESCRIPTION
add support to a vertical aligned (y wise) quiverkey.

The label for N and S are still over the arrow, but for label=W (my case) this snippet works.

Useful for a x-z plane quiver plot when the quiver arrows components have different units and user need to provide information about this in the plot. The currently default behaviour is to only plot a horizontal (x) quiverkey, while the vertical is assumed to be the same.

This also support the user to select if he wants to make a key that is horizontal or vertical aligned. Say that the flow is along y and the quiverkey is horizontal, the reader always need to rotate in his mind the vector to have a grasp about the magnitude.
